### PR TITLE
User Profiles and Contacts providers

### DIFF
--- a/src/DataFixtures/UsersFixtures.php
+++ b/src/DataFixtures/UsersFixtures.php
@@ -3,6 +3,8 @@
 namespace App\DataFixtures;
 
 use App\Entity\User;
+use App\Entity\UserProfile;
+use App\Entity\UserProfileContacts;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\Persistence\ObjectManager;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
@@ -22,7 +24,21 @@ class UsersFixtures extends Fixture
         $user->username = 'tester_fixture';
         $user->email = 'tester@fixture.com';
         $user->setPassword('123456', $this->encoder);
+
+        $profile = $user->getProfile();
+        $profile->setUser($user);
+        $profile->setFirstName('First')->setLastName('Last');
+
+        for ($i = 3; $i-->= 0;) {
+            $contact = new UserProfileContacts();
+            $contact->provider = "TestProvider #{$i}";
+            $contact->url = "https://test.com/{$i}/info";
+            $contact->setProfile($profile);
+            $manager->persist($contact);
+        }
+
         $manager->persist($user);
+        $manager->persist($profile);
         $manager->flush();
     }
 }

--- a/src/DataFixtures/UsersFixtures.php
+++ b/src/DataFixtures/UsersFixtures.php
@@ -26,19 +26,14 @@ class UsersFixtures extends Fixture
         $user->setPassword('123456', $this->encoder);
 
         $profile = $user->getProfile();
-        $profile->setUser($user);
-        $profile->setFirstName('First')->setLastName('Last');
+        $profile->first_name = 'First';
+        $profile->last_name = 'Last';
 
         for ($i = 3; $i-->= 0;) {
-            $contact = new UserProfileContacts();
-            $contact->provider = "TestProvider #{$i}";
-            $contact->url = "https://test.com/{$i}/info";
-            $contact->setProfile($profile);
-            $manager->persist($contact);
+            $profile->addContacts("TestProvider #{$i}", "https://test.com/{$i}/info");
         }
 
         $manager->persist($user);
-        $manager->persist($profile);
         $manager->flush();
     }
 }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -28,6 +28,12 @@ class User implements UserInterface, \Serializable
     private $id;
 
     /**
+     * @var $profile UserProfile
+     * @ORM\OneToOne(targetEntity="App\Entity\UserProfile", mappedBy="user", cascade={"persist", "remove"})
+     */
+    private $profile;
+
+    /**
      * @ORM\Column(type="string", length=255, unique=true)
      */
     public $email;
@@ -56,6 +62,12 @@ class User implements UserInterface, \Serializable
     public function __construct()
     {
         $this->addRole(self::ROLE_USER);
+        $this->profile = (new UserProfile())->setUser($this);
+    }
+
+    public function getProfile(): UserProfile
+    {
+        return $this->profile;
     }
 
     public function getId(): ?int

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -62,7 +62,7 @@ class User implements UserInterface, \Serializable
     public function __construct()
     {
         $this->addRole(self::ROLE_USER);
-        $this->profile = (new UserProfile())->setUser($this);
+        $this->profile = new UserProfile($this);
     }
 
     public function getProfile(): UserProfile

--- a/src/Entity/UserProfile.php
+++ b/src/Entity/UserProfile.php
@@ -41,12 +41,12 @@ class UserProfile
     /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
-    private $first_name;
+    public $first_name;
 
     /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
-    private $last_name;
+    public $last_name;
 
     /**
      * @ORM\Column(type="date", nullable=true)
@@ -56,15 +56,16 @@ class UserProfile
     /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
-    private $about;
+    public $about;
 
     /**
      * @ORM\Column(type="string", length=255, nullable=true)
      */
-    private $public_email;
+    public $public_email;
 
-    public function __construct()
+    public function __construct(User $user)
     {
+        $this->user = $user;
         $this->contacts = new ArrayCollection();
     }
 
@@ -85,12 +86,20 @@ class UserProfile
     }
 
     /**
-     * @param User $user
+     * @return mixed
+     */
+    public function getBirthDate()
+    {
+        return $this->birth_date;
+    }
+
+    /**
+     * @param \DateTime $birth_date
      * @return UserProfile
      */
-    public function setUser(User $user): UserProfile
+    public function setBirthDate(\DateTime $birth_date)
     {
-        $this->user = $user;
+        $this->birth_date = $birth_date;
         return $this;
     }
 
@@ -103,93 +112,18 @@ class UserProfile
     }
 
     /**
-     * @return mixed
-     *
+     * @param $name
+     * @param $url
+     * @return $this
      */
-    public function getFirstName()
+    public function addContacts($name, $url)
     {
-        return $this->first_name;
-    }
+        $contact = new UserProfileContacts($this);
+        $contact->provider = $name;
+        $contact->url = $url;
 
-    /**
-     * @param mixed $first_name
-     * @return UserProfile
-     */
-    public function setFirstName($first_name)
-    {
-        $this->first_name = $first_name;
-        return $this;
-    }
+        $this->contacts->add($contact);
 
-    /**
-     * @return mixed
-     */
-    public function getLastName()
-    {
-        return $this->last_name;
-    }
-
-    /**
-     * @param mixed $last_name
-     * @return UserProfile
-     */
-    public function setLastName($last_name)
-    {
-        $this->last_name = $last_name;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBirthDate()
-    {
-        return $this->birth_date;
-    }
-
-    /**
-     * @param mixed $birth_date
-     * @return UserProfile
-     */
-    public function setBirthDate($birth_date)
-    {
-        $this->birth_date = $birth_date;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getAbout()
-    {
-        return $this->about;
-    }
-
-    /**
-     * @param mixed $about
-     * @return UserProfile
-     */
-    public function setAbout($about)
-    {
-        $this->about = $about;
-        return $this;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getPublicEmail()
-    {
-        return $this->public_email;
-    }
-
-    /**
-     * @param mixed $public_email
-     * @return UserProfile
-     */
-    public function setPublicEmail($public_email)
-    {
-        $this->public_email = $public_email;
         return $this;
     }
 }

--- a/src/Entity/UserProfile.php
+++ b/src/Entity/UserProfile.php
@@ -1,0 +1,195 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Security\Core\User\UserInterface;
+use JMS\Serializer\Annotation\Exclude;
+use JMS\Serializer\Annotation\Expose;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="users_profiles")
+ */
+class UserProfile
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @var $user User
+     * @ORM\OneToOne(targetEntity="App\Entity\User", inversedBy="profile")
+     * @ORM\JoinColumn(nullable=false)
+     */
+    private $user;
+
+    /**
+     * @var $contacts UserProfileContacts[]|ArrayCollection
+     * @ORM\OneToMany(targetEntity="App\Entity\UserProfileContacts", mappedBy="contacts", cascade={"persist", "remove"})
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $contacts;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $first_name;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $last_name;
+
+    /**
+     * @ORM\Column(type="date", nullable=true)
+     */
+    private $birth_date;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $about;
+
+    /**
+     * @ORM\Column(type="string", length=255, nullable=true)
+     */
+    private $public_email;
+
+    public function __construct()
+    {
+        $this->contacts = new ArrayCollection();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return User
+     */
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param User $user
+     * @return UserProfile
+     */
+    public function setUser(User $user): UserProfile
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * @return UserProfileContacts[]|ArrayCollection
+     */
+    public function getContacts()
+    {
+        return $this->contacts;
+    }
+
+    /**
+     * @return mixed
+     *
+     */
+    public function getFirstName()
+    {
+        return $this->first_name;
+    }
+
+    /**
+     * @param mixed $first_name
+     * @return UserProfile
+     */
+    public function setFirstName($first_name)
+    {
+        $this->first_name = $first_name;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getLastName()
+    {
+        return $this->last_name;
+    }
+
+    /**
+     * @param mixed $last_name
+     * @return UserProfile
+     */
+    public function setLastName($last_name)
+    {
+        $this->last_name = $last_name;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBirthDate()
+    {
+        return $this->birth_date;
+    }
+
+    /**
+     * @param mixed $birth_date
+     * @return UserProfile
+     */
+    public function setBirthDate($birth_date)
+    {
+        $this->birth_date = $birth_date;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getAbout()
+    {
+        return $this->about;
+    }
+
+    /**
+     * @param mixed $about
+     * @return UserProfile
+     */
+    public function setAbout($about)
+    {
+        $this->about = $about;
+        return $this;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getPublicEmail()
+    {
+        return $this->public_email;
+    }
+
+    /**
+     * @param mixed $public_email
+     * @return UserProfile
+     */
+    public function setPublicEmail($public_email)
+    {
+        $this->public_email = $public_email;
+        return $this;
+    }
+}

--- a/src/Entity/UserProfileContacts.php
+++ b/src/Entity/UserProfileContacts.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Entity;
+
+use Doctrine\ORM\Mapping as ORM;
+use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
+use Symfony\Component\Security\Core\User\UserInterface;
+use JMS\Serializer\Annotation\Exclude;
+use JMS\Serializer\Annotation\Expose;
+
+/**
+ * @ORM\Entity
+ * @ORM\Table(name="users_profiles_contacts")
+ */
+class UserProfileContacts
+{
+    /**
+     * @ORM\Id()
+     * @ORM\GeneratedValue()
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="App\Entity\UserProfile", inversedBy="contacts")
+     * @ORM\JoinColumn(nullable=true)
+     */
+    private $profile;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    public $provider;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    public $url;
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param mixed $profile
+     * @return UserProfileContacts
+     */
+    public function setProfile(UserProfile $profile): self
+    {
+        $this->profile = $profile;
+        return $this;
+    }
+}

--- a/src/Entity/UserProfileContacts.php
+++ b/src/Entity/UserProfileContacts.php
@@ -4,11 +4,6 @@ declare(strict_types=1);
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
-use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
-use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
-use Symfony\Component\Security\Core\User\UserInterface;
-use JMS\Serializer\Annotation\Exclude;
-use JMS\Serializer\Annotation\Expose;
 
 /**
  * @ORM\Entity
@@ -39,6 +34,11 @@ class UserProfileContacts
      */
     public $url;
 
+    public function __construct(UserProfile $userProfile)
+    {
+        $this->profile = $userProfile;
+    }
+
     /**
      * @return mixed
      */
@@ -48,12 +48,10 @@ class UserProfileContacts
     }
 
     /**
-     * @param mixed $profile
-     * @return UserProfileContacts
+     * @return UserProfile
      */
-    public function setProfile(UserProfile $profile): self
+    public function getProfile()
     {
-        $this->profile = $profile;
-        return $this;
+        return $this->profile;
     }
 }

--- a/tests/Functional/Repository/UserRepositoryTest.php
+++ b/tests/Functional/Repository/UserRepositoryTest.php
@@ -47,7 +47,13 @@ class UserRepositoryTest extends KernelTestCase
             $this->entityManager->persist($this->user);
             $this->entityManager->flush();
         } catch (ORMException $e) {
-            $this->fail('User not saved, error: ' . $e->getMessage());
+            $debugData = [
+                'message' => $e->getMessage(),
+                'code' => $e->getCode(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ];
+            $this->fail('User not saved, error: ' . var_export($debugData));
         }
 
         return $this->user;

--- a/tests/Unit/Entity/UserProfileContactsTest.php
+++ b/tests/Unit/Entity/UserProfileContactsTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use App\Entity\UserProfile;
+use App\Entity\UserProfileContacts;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserProfileContactsTest extends KernelTestCase
+{
+    /**
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * @var UserProfile
+     */
+    protected $profile;
+
+    /**
+     * @var UserProfileContacts
+     */
+    protected $contacts;
+
+    protected function setUp()
+    {
+        $this->user = new User();
+        $this->profile = $this->user->getProfile();
+        $this->contacts = new UserProfileContacts($this->profile);
+    }
+
+    protected function tearDown()
+    {
+        $this->user = null;
+        $this->profile = null;
+        $this->contacts = null;
+        unset($this->user, $this->profile, $this->contacts);
+    }
+
+    public function testGetProfile()
+    {
+        $this->assertEquals($this->profile, $this->contacts->getProfile());
+    }
+
+    public function testGetId()
+    {
+        $this->assertNull($this->contacts->getId());
+    }
+}

--- a/tests/Unit/Entity/UserProfileTest.php
+++ b/tests/Unit/Entity/UserProfileTest.php
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\User;
+use App\Entity\UserProfile;
+use App\Entity\UserProfileContacts;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class UserProfileTest extends KernelTestCase
+{
+    /**
+     * @var User
+     */
+    protected $user;
+
+    /**
+     * @var UserProfile
+     */
+    protected $profile;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function setUp()
+    {
+        $this->user = new User();
+        $this->profile = $this->user->getProfile();
+    }
+
+    protected function tearDown()
+    {
+        $this->user = null;
+        $this->profile = null;
+        unset($this->user, $this->profile);
+    }
+
+    public function testIdIsEmpty()
+    {
+        $this->assertNull($this->profile->getId());
+    }
+
+    public function testGetUser()
+    {
+        $user = $this->profile->getUser();
+        $this->assertEquals($this->user, $user);
+    }
+
+    public function testGetBirthDate()
+    {
+        $this->assertNull($this->profile->getBirthDate());
+    }
+
+    public function testSetBirthDate()
+    {
+        $birthDate = (new \DateTime())->modify('-20 years');
+        $this->profile->setBirthDate($birthDate);
+        $this->assertEquals($birthDate, $this->profile->getBirthDate());
+    }
+
+    public function testGetContacts()
+    {
+        $contacts = $this->profile->getContacts();
+        $this->assertEquals(0, $contacts->count());
+    }
+
+    public function testAddContacts()
+    {
+        $contacts_name = 'test1';
+        $contacts_url = 'test2';
+
+        $result = $this->profile->addContacts($contacts_name, $contacts_url);
+        $contacts = $this->profile->getContacts();
+
+        $this->assertEquals($this->profile, $result);
+        $this->assertEquals(1, $contacts->count());
+        $this->assertTrue($contacts->get(0) instanceof UserProfileContacts);
+    }
+}


### PR DESCRIPTION
Now users have own profiles (one to one) and profiles have contacts providers (actually its just "Name: Value" storage for user contacts, so user can setup as much contacts as he need, like "Instagram: https://instagram.com/{username}" and other social pages)

I need to write tests before merging this PR. Maybe tomorrow will do that. But current tests working fine even with new Entities and relations.